### PR TITLE
Specify the numpy version to avoid warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ shortuuid
 accelerate==0.21.0
 peft==0.4.0
 bitsandbytes==0.41.0
-numpy
+numpy==1.26.4
 scikit-learn==1.2.2
 gradio==3.35.2
 gradio_client==0.2.9


### PR DESCRIPTION
When using an older version of `requirements.txt`, not specifying the `numpy` version can result in the installation of the latest `numpy`, which might cause warnings:

```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.2 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some modules may need to rebuild instead e.g., with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```

To avoid this warning, specify the `numpy` version in`requirements.txt` file. 
This ensures that a version of `numpy` below 2.0 is installed, preventing the warning and potential crashes.